### PR TITLE
Match quoted input as one input argument

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -181,6 +181,21 @@ function inject(bot) {
         commands.map(addCommand);
     }
 
+    function parseTokens(input) {
+        const tokens = [];
+
+        const regex = /([^\s"']+)|"(?:[^"\\]|\\.)*"|'([^']*)'/g;
+        let match;
+
+        do {
+            match = regex.exec(input);
+            if (match) tokens.push(match[3] || match[2] || match[1]);
+        }
+        while (match);
+
+        return tokens;
+    }
+
     function processCommand(username, message, isConsole = false) {
         // Checks wether the command request is valid
         if (!isConsole) {
@@ -192,7 +207,7 @@ function inject(bot) {
             message = message.substring(configs.prefix.length);
         }
 
-        const [inputCommand, ...inputArgs] = message.split(" ");
+        const [inputCommand, ...inputArgs] = parseTokens(message);
 
         // Goes through all known commands and tries to run the matching one
         const command = getCommand(inputCommand);


### PR DESCRIPTION
As original function only matches anything that is separated by spaces, therefore it is impossible to perform something like
`BuyThoseItem Diamond Hoe Beetroot Seeds`

So my proposed solution would be grouping spaced input with quoted string while still allows non-quoted input
Example 1: `BuyThoseItem "Diamond Hoe" "Beetroot Seeds"`
Example 2: `BuyThoseItem Wheat Apple`
Example 3: `Say "I\"m hungry"` (Quote can be escaped)